### PR TITLE
Set base box for parallels environment to parallels/ubuntu-1404

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,16 @@
 
 To build a new base box:
 
-* clone this repository
+* Clone this repository
 * cd to the directory housing the Vagrantfile
-* run "vagrant box update"
-* run "vagrant up"
-* shell into the VM with "vagrant ssh"
-* run "sudo apt-get clean"
-* run "sudo dd if=/dev/zero of=/EMPTY bs=1M" (note, this step will take a while, up to 10 minutes)
-* run "sudo rm -f /EMPTY"
-* run "cat /dev/null > ~/.bash_history && history -c && exit" (this will exit you from the vm back to your host environment)
-* run "vagrant package --output <mynewbox>.box"
-* upload as a new version to https://atlas.hashicorp.com/savas/boxes/trusty64/
+* Run `vagrant box update`
+* Run `vagrant up`
+* Optionally (to reduce image size): 
+    * Shell into the VM with `vagrant ssh`
+    * run `sudo dd if=/dev/zero of=/EMPTY bs=1M` (note, this step will take a while, up to 10 minutes)
+    * run `sudo rm -f /EMPTY`
+* Run "vagrant package --output <mynewbox>.box"
+* Upload as a new version to https://atlas.hashicorp.com/savas/boxes/trusty64/
 
 If you are building using parallels, your environment variable `VAGRANT_DEFAULT_PROVIDER` **must** be set to `parallels`. This is because the vagrantfile makes it difficult to actually read the provider variable at runtime, so we rely on the `VAGRANT_DEFAULT_PROVIDER` variable as a proxy. Run `export VAGRANT_DEFAULT_PROVIDER="parallels"` before the above steps. See more at https://groups.google.com/forum/#!topic/vagrant-up/XIxGdm78s4I
 

--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ To build a new base box:
 * run "vagrant package --output <mynewbox>.box"
 * upload as a new version to https://atlas.hashicorp.com/savas/boxes/trusty64/
 
+If you are building using parallels, your environment variable `VAGRANT_DEFAULT_PROVIDER` **must** be set to `parallels`. This is because the vagrantfile makes it difficult to actually read the provider variable at runtime, so we rely on the `VAGRANT_DEFAULT_PROVIDER` variable as a proxy. Run `export VAGRANT_DEFAULT_PROVIDER="parallels"` before the above steps. See more at https://groups.google.com/forum/#!topic/vagrant-up/XIxGdm78s4I
+

--- a/README.md
+++ b/README.md
@@ -6,11 +6,7 @@ To build a new base box:
 * cd to the directory housing the Vagrantfile
 * Run `vagrant box update`
 * Run `vagrant up`
-* Optionally (to reduce image size): 
-    * Shell into the VM with `vagrant ssh`
-    * run `sudo dd if=/dev/zero of=/EMPTY bs=1M` (note, this step will take a while, up to 10 minutes)
-    * run `sudo rm -f /EMPTY`
-* Run "vagrant package --output <mynewbox>.box"
+* Run `vagrant package --output <mynewbox>.box`
 * Upload as a new version to https://atlas.hashicorp.com/savas/boxes/trusty64/
 
 If you are building using parallels, your environment variable `VAGRANT_DEFAULT_PROVIDER` **must** be set to `parallels`. This is because the vagrantfile makes it difficult to actually read the provider variable at runtime, so we rely on the `VAGRANT_DEFAULT_PROVIDER` variable as a proxy. Run `export VAGRANT_DEFAULT_PROVIDER="parallels"` before the above steps. See more at https://groups.google.com/forum/#!topic/vagrant-up/XIxGdm78s4I

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -130,6 +130,7 @@ sudo a2ensite mass_virtual.conf
 sudo service apache2 restart
 SCRIPT
   config.vm.provision "shell", inline: $script
+
   # Installing Composer
 $script = <<SCRIPT
 echo Installing Composer...

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,8 +16,9 @@ Vagrant.configure(2) do |config|
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--memory", 2048]
   end
-  config.vm.provider :parallels do |parallels|
-    config.vm.box = "parallels/ubuntu-14.04"
+
+  config.vm.provider "parallels" do |parallels, override|
+    override.vm.box = "parallels/ubuntu-14.04"
   end
 
   project = 'default'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -155,8 +155,6 @@ SCRIPT
   #Making box as small as possible after provisioning
   $script = <<SCRIPT
 sudo apt-get clean
-sudo dd if=/dev/zero of=/EMPTY bs=1M
-sudo rm -f /EMPTY
 cat /dev/null > ~/.bash_history && history -c && exit
 SCRIPT
   config.vm.provision "shell", inline: $script

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,18 @@ Vagrant.configure(2) do |config|
   config.ssh.insert_key = false
   config.ssh.forward_agent  = true
   config.vm.network :private_network, ip: "192.168.88.96"
-  
+
+  # Extra configuration for parallels.
+  $script = <<SCRIPT
+echo Installing software-properties-common
+sudo apt-get install -y software-properties-common
+echo Installing curl
+sudo apt-get install -y curl
+SCRIPT
+  if ENV['VAGRANT_DEFAULT_PROVIDER'] == 'parallels'
+    config.vm.provision "shell", inline: $script
+  end
+
   # Adding a package repo for php 5.6 and installing vim and git
   $script = <<SCRIPT
 mkdir -p /var/www/#{project}.dev/www/web
@@ -102,6 +113,7 @@ sudo npm install selenium-standalone@latest -g
 sudo npm install --global gulp-cli
 SCRIPT
   config.vm.provision "shell", inline: $script
+
   # Configuring Apache...
   $script = <<SCRIPT
 echo Configuring Apache...

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure(2) do |config|
     vb.customize ["modifyvm", :id, "--memory", 2048]
   end
 
-  config.vm.provider "parallels" do |parallels, override|
+  config.vm.provider :parallels do |parallels, override|
     override.vm.box = "parallels/ubuntu-14.04"
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,9 @@ Vagrant.configure(2) do |config|
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--memory", 2048]
   end
+  config.vm.provider :parallels do |parallels|
+    config.vm.box = "parallels/ubuntu-14.04"
+  end
 
   project = 'default'
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -153,6 +153,15 @@ drupal init --override
 SCRIPT
   config.vm.provision "shell", inline: $script
 
+  # Make diskspace easy to compress -- for non-parallels machines.
+  $script = <<SCRIPT
+-sudo dd if=/dev/zero of=/EMPTY bs=1M
+-sudo rm -f /EMPTY
+SCRIPT
+  if ENV['VAGRANT_DEFAULT_PROVIDER'] != 'parallels'
+    config.vm.provision "shell", inline: $script
+  end
+
   #Making box as small as possible after provisioning
   $script = <<SCRIPT
 sudo apt-get clean


### PR DESCRIPTION
This PR adds support for parallels by conditionally enabling the parallels Ubuntu 14.04 base box instead of the Virtualbox equivalent.